### PR TITLE
fix Allow header to be what's allowed

### DIFF
--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -30,7 +30,7 @@ export default async (req, res) => {
 
       break
     default:
-      res.setHeader('Allow', ['GET', 'PUT'])
+      res.setHeader('Allow', ['GET', 'POST'])
       res.status(405).end(`Method ${method} Not Allowed`)
   }
 }


### PR DESCRIPTION
`PUT` isn't actually handled by the API, but `POST` is. Probably a typo